### PR TITLE
Add script to detect log4j usages in sbt builds

### DIFF
--- a/batch-changes/README.md
+++ b/batch-changes/README.md
@@ -7,6 +7,7 @@ This directory contains Sourcegraph [Batch Changes](https://docs.sourcegraph.com
 - [upgrade-log4j-gradle.yml](upgrade-log4j-gradle.yml): Force usage of safe log4j dependency versions (including for transitive dependencies) in all Gradle projects (using `build.gradle` files) that use affected log4j dependency versions.
 - [detect-log4j-gradle.yml](detect-log4j-gradle.yml): Detect Gradle projects (using `build.gradle` files) that use affected log4j dependency versions and leave a `fixme` file in the repository to create a dynamic list of affected repositories.
 - [detect-log4j-maven.yml](detect-log4j-gradle.yml): Detect Maven projects (using `pom.xml` files) that use affected log4j dependency versions and and leave a `fixme` file in the repository to create a dynamic list of affected repositories
+- [detect-log4j-sbt.yml](detect-log4j-sbt.yml): Detect sbt projects (using `project/build.properties` files with a declared `sbt.version` setting) that use affected log4j dependency versions and leave a `fixme` file in the repository to create a dynamic list of affected repositories.
 
 #### About Batch Changes
 

--- a/batch-changes/detect-log4j-sbt.yml
+++ b/batch-changes/detect-log4j-sbt.yml
@@ -30,24 +30,29 @@ steps:
           )
         }
         import autoImport._
-        override def projectSettings: Seq[Setting[_]] =
-          List(Compile, Test).flatMap(c =>
-            inConfig(c)(
-              List(
-                detectVulnerableLog4j := {
-                  val projectName = thisProject.value.id
-                  val l = streams.value.log
-                  dependencyClasspath.value.foreach { entry =>
-                    analyzeDependencyClasspathEntry(projectName, c, entry.data, l)
-                  }
-                }
+        override def projectSettings: Seq[Setting[_]] = List(
+          detectVulnerableLog4j := {
+            val updateReport = update.value
+            val projectName = thisProject.value.id
+            val l = streams.value.log
+            for {
+              configuration <- updateReport.configurations
+              module <- configuration.modules
+              (artifact, file) <- module.artifacts
+            } {
+              analyzeDependencyClasspathEntry(
+                projectName,
+                configuration.configuration.name,
+                file,
+                l
               )
-            )
-          )
+            }
+          }
+        )
       
         def analyzeDependencyClasspathEntry(
             projectName: String,
-            config: Configuration,
+            configName: String,
             file: File,
             logger: Logger
         ): Unit = {
@@ -61,7 +66,7 @@ steps:
                   element.getName() == "org/apache/logging/log4j/core/lookup/JndiLookup.class"
                 ) {
                   logger.error(
-                    s"CVE-2021-44228: the config '${config.name}' in the project '$projectName' depends on a vulnerable jar file ${file.absolutePath}"
+                    s"CVE-2021-44228: the config '$configName' in the project '$projectName' depends on a vulnerable jar file ${file.absolutePath}"
                   )
                 }
               }

--- a/batch-changes/detect-log4j-sbt.yml
+++ b/batch-changes/detect-log4j-sbt.yml
@@ -1,0 +1,85 @@
+name: upgrade-log4j-cve-2021-44228-sbt
+description: Detects dependencies on log4j jars that are affected by [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)
+
+on:
+  - repositoriesMatchingQuery: file:project/build.properties sbt.version
+
+# In each repository,
+steps:
+  - run: |
+      cat << 'EOF' >> project/Log4shellPlugin.scala
+      package com.sourcegraph.sbtsourcegraph
+      
+      import sbt._
+      import sbt.Keys._
+      import sbt.plugins.JvmPlugin
+      import java.util.jar.JarFile
+      
+      object Log4shellPlugin extends AutoPlugin {
+        override def trigger: PluginTrigger = allRequirements
+        override def requires = JvmPlugin
+        object autoImport {
+          val detectVulnerableLog4j = taskKey[Unit](
+            "reports an error if we detect a vulnerable log4j dependency"
+          )
+        }
+        import autoImport._
+        override def projectSettings: Seq[Setting[_]] =
+          List(Compile, Test).flatMap(c =>
+            inConfig(c)(
+              List(
+                detectVulnerableLog4j := {
+                  val projectName = thisProject.value.id
+                  val l = streams.value.log
+                  dependencyClasspath.value.foreach { entry =>
+                    analyzeDependencyClasspathEntry(projectName, c, entry.data, l)
+                  }
+                }
+              )
+            )
+          )
+      
+        def analyzeDependencyClasspathEntry(
+            projectName: String,
+            config: Configuration,
+            file: File,
+            logger: Logger
+        ): Unit = {
+          if (file.getName().endsWith(".jar")) {
+            val jar = new JarFile(file)
+            val entries = jar.entries()
+            try {
+              while (entries.hasMoreElements()) {
+                val element = entries.nextElement()
+                if (
+                  element.getName() == "org/apache/logging/log4j/core/lookup/JndiLookup.class"
+                ) {
+                  logger.error(
+                    s"CVE-2021-44228: the config '${config.name}' in the project '$projectName' depends on a vulnerable jar file ${file.absolutePath}"
+                  )
+                }
+              }
+            } finally {
+              jar.close()
+            }
+          }
+        }
+      }
+      EOF
+      curl -L https://raw.githubusercontent.com/sbt/sbt/develop/sbt > sbt
+      chmod +x sbt
+      ./sbt detectVulnerableLog4j | grep CVE-2021-44228 > "$OUTPUT_FILE"
+    container: openjdk:11
+    env:
+      OUTPUT_FILE: "fixme-log4j-vulnerabilities.txt"
+
+# Describe the changeset (e.g., GitHub pull request) you want for each repository.
+changesetTemplate:
+  title: Detected vulnerable log4j dependency (CVE-2021-44228)
+  body: |
+    This PR identifies jar files that are on the classpath of this codebase that are affected by [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228).
+    Please urgently fix this issue by following the steps in TODO.
+  branch: batches/detect-log4j-cve-2021-44228-maven
+  commit:
+    message: Detect log4j vulnerability (CVE-2021-44228)
+  published: false

--- a/batch-changes/detect-log4j-sbt.yml
+++ b/batch-changes/detect-log4j-sbt.yml
@@ -1,5 +1,11 @@
 name: upgrade-log4j-cve-2021-44228-sbt
-description: Detects dependencies on log4j jars that are affected by [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)
+description: |
+  Detects dependencies on log4j jars that are affected by [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)
+
+  Dependencies from private Artifactory instances will fail to resolve because
+  the default Docker container is mozilla/sbt and will only try to download
+  dependencies from Maven Central. Change the Docker container setting to match
+  your own CI build to fix dependency resolution errors.
 
 on:
   - repositoriesMatchingQuery: file:project/build.properties sbt.version
@@ -66,10 +72,8 @@ steps:
         }
       }
       EOF
-      curl -L https://raw.githubusercontent.com/sbt/sbt/develop/sbt > sbt
-      chmod +x sbt
       ./sbt detectVulnerableLog4j | grep CVE-2021-44228 > "$OUTPUT_FILE"
-    container: openjdk:11
+    container: mozilla/sbt
     env:
       OUTPUT_FILE: "fixme-log4j-vulnerabilities.txt"
 

--- a/batch-changes/detect-log4j-sbt.yml
+++ b/batch-changes/detect-log4j-sbt.yml
@@ -8,7 +8,7 @@ description: |
   your own CI build to fix dependency resolution errors.
 
 on:
-  - repositoriesMatchingQuery: file:project/build.properties sbt.version
+  - repositoriesMatchingQuery: file:^project/build.properties sbt.version
 
 # In each repository,
 steps:

--- a/batch-changes/detect-log4j-sbt.yml
+++ b/batch-changes/detect-log4j-sbt.yml
@@ -72,7 +72,7 @@ steps:
         }
       }
       EOF
-      ./sbt detectVulnerableLog4j | grep CVE-2021-44228 > "$OUTPUT_FILE"
+      sbt detectVulnerableLog4j | grep CVE-2021-44228 > "$OUTPUT_FILE"
     container: mozilla/sbt
     env:
       OUTPUT_FILE: "fixme-log4j-vulnerabilities.txt"


### PR DESCRIPTION
Following up from https://sourcegraph.slack.com/archives/C02R4E407S4/p1639521036315800

The `detect-log4j` branch of this repository can be used for testing
purposes https://github.com/sourcegraph/sbt-sourcegraph/tree/detect-log4j